### PR TITLE
Bump bcrypt to 3.1.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails',                '4.2.0'
-gem 'bcrypt',               '3.1.7'
+gem 'bcrypt',               '3.1.11'
 gem 'bootstrap-sass',       '3.2.0.0'
 gem 'sass-rails',           '5.0.3'
 gem 'uglifier',             '2.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,6 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (6.0.3)
-    bcrypt (3.1.7)
     binding_of_caller (0.7.3.pre1)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.0)
@@ -203,7 +202,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt (= 3.1.7)
+  bcrypt (= 3.1.11)
   bootstrap-sass (= 3.2.0.0)
   byebug (= 3.4.0)
   coffee-rails (= 4.1.0)
@@ -227,4 +226,4 @@ DEPENDENCIES
   web-console (= 2.0.0.beta3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Bumps [bcrypt](https://github.com/codahale/bcrypt-ruby) to 3.1.11.
- [Changelog](https://github.com/codahale/bcrypt-ruby/blob/master/CHANGELOG)
- [Commits](https://github.com/codahale/bcrypt-ruby/commits)
