### PR TITLE
Bump bootstrap-sass to 3.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails',                '4.2.0'
 gem 'bcrypt',               '3.1.7'
-gem 'bootstrap-sass',       '3.2.0.0'
+gem 'bootstrap-sass',       '3.3.6'
 gem 'sass-rails',           '5.0.3'
 gem 'uglifier',             '2.5.3'
 gem 'coffee-rails',         '4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,6 @@ GEM
     bcrypt (3.1.7)
     binding_of_caller (0.7.3.pre1)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass (3.2.0.0)
-      sass (~> 3.2)
     builder (3.2.2)
     byebug (3.4.0)
       columnize (~> 0.8)
@@ -163,7 +161,6 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.0)
     ruby-progressbar (1.7.5)
-    sass (3.4.18)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -204,7 +201,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (= 3.1.7)
-  bootstrap-sass (= 3.2.0.0)
+  bootstrap-sass (= 3.3.6)
   byebug (= 3.4.0)
   coffee-rails (= 4.1.0)
   guard-minitest (= 2.3.1)
@@ -227,4 +224,4 @@ DEPENDENCIES
   web-console (= 2.0.0.beta3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Bumps [bootstrap-sass](https://github.com/twbs/bootstrap-sass) to 3.3.6.
- [Changelog](https://github.com/twbs/bootstrap-sass/blob/master/CHANGELOG.md)
- [Commits](https://github.com/twbs/bootstrap-sass/commits)
