### PR TITLE
Bump jbuilder to 2.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'uglifier',             '2.5.3'
 gem 'coffee-rails',         '4.1.0'
 gem 'jquery-rails',         '4.0.3'
 gem 'turbolinks',           '2.3.0'
-gem 'jbuilder',             '2.2.3'
+gem 'jbuilder',             '2.4.1'
 gem 'pry-rails'
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,12 +30,6 @@ GEM
       activemodel (= 4.2.0)
       activesupport (= 4.2.0)
       arel (~> 6.0)
-    activesupport (4.2.0)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (6.0.3)
     bcrypt (3.1.7)
@@ -77,15 +71,10 @@ GEM
     guard-minitest (2.3.1)
       guard (~> 2.0)
       minitest (>= 3.0)
-    i18n (0.7.0)
-    jbuilder (2.2.3)
-      activesupport (>= 3.0.0, < 5)
-      multi_json (~> 1.2)
     jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -100,13 +89,11 @@ GEM
       minitest (> 1.2.0)
       rails (>= 2.3.3)
     mini_portile (0.6.2)
-    minitest (5.8.0)
     minitest-reporters (1.0.5)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    multi_json (1.11.2)
     nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -184,12 +171,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.9)
     thor (0.19.1)
-    thread_safe (0.3.5)
     tilt (1.4.1)
     turbolinks (2.3.0)
       coffee-rails
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -208,7 +192,7 @@ DEPENDENCIES
   byebug (= 3.4.0)
   coffee-rails (= 4.1.0)
   guard-minitest (= 2.3.1)
-  jbuilder (= 2.2.3)
+  jbuilder (= 2.4.1)
   jquery-rails (= 4.0.3)
   mini_backtrace (= 0.1.3)
   minitest-reporters (= 1.0.5)
@@ -227,4 +211,4 @@ DEPENDENCIES
   web-console (= 2.0.0.beta3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Bumps [jbuilder](https://github.com/rails/jbuilder) to 2.4.1.
- [Changelog](https://github.com/rails/jbuilder/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rails/jbuilder/commits)
