### PR TITLE
Bump sdoc to 0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jbuilder',             '2.2.3'
 gem 'pry-rails'
 
 group :doc do
-  gem 'sdoc',                 '0.4.0'
+  gem 'sdoc',                 '0.4.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -161,7 +160,6 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rdoc (4.2.0)
     ruby-progressbar (1.7.5)
     sass (3.4.18)
     sass-rails (5.0.3)
@@ -170,9 +168,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    sdoc (0.4.0)
-      json (~> 1.8)
-      rdoc (~> 4.0, < 5.0)
     shellany (0.0.1)
     slop (3.6.0)
     spring (1.1.3)
@@ -219,7 +214,7 @@ DEPENDENCIES
   rails (= 4.2.0)
   rails_12factor (= 0.0.2)
   sass-rails (= 5.0.3)
-  sdoc (= 0.4.0)
+  sdoc (= 0.4.1)
   spring (= 1.1.3)
   sqlite3 (= 1.3.9)
   turbolinks (= 2.3.0)
@@ -227,4 +222,4 @@ DEPENDENCIES
   web-console (= 2.0.0.beta3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Bumps [sdoc](https://github.com/voloko/sdoc) to 0.4.1.
- [Changelog](https://github.com/zzak/sdoc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/voloko/sdoc/commits)
