### PR TITLE
Bump sqlite3 to 1.3.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :doc do
 end
 
 group :development, :test do
-  gem 'sqlite3',     '1.3.9'
+  gem 'sqlite3',     '1.3.11'
   gem 'byebug',      '3.4.0'
   gem 'web-console', '2.0.0.beta3'
   gem 'spring',      '1.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.9)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -221,10 +220,10 @@ DEPENDENCIES
   sass-rails (= 5.0.3)
   sdoc (= 0.4.0)
   spring (= 1.1.3)
-  sqlite3 (= 1.3.9)
+  sqlite3 (= 1.3.11)
   turbolinks (= 2.3.0)
   uglifier (= 2.5.3)
   web-console (= 2.0.0.beta3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Bumps [sqlite3](https://github.com/sparklemotion/sqlite3-ruby) to 1.3.11.
- [Changelog](https://github.com/sparklemotion/sqlite3-ruby/blob/master/CHANGELOG.rdoc)
- [Commits](https://github.com/sparklemotion/sqlite3-ruby/commits)
